### PR TITLE
Update metadata to use new endpoints

### DIFF
--- a/src/frontend/shortlist/src/App.vue
+++ b/src/frontend/shortlist/src/App.vue
@@ -61,11 +61,6 @@ function appAccountSignup(payload) {
 }
 
 function appAuthLogin(payload) {
-  console.log("accountLogin", payload.email);
-  let requestPayload = {
-    email: payload.email,
-    password: payload.password,
-  };
 
   let success = (result) => {
     console.log("success: ", result.data);
@@ -82,7 +77,7 @@ function appAuthLogin(payload) {
       alert("Could not login.");
     }
   };
-  let req = apiClient.authLogin(requestPayload, success, fail);
+  let req = apiClient.authLogin(payload, success, fail);
   req.execute();
 }
 
@@ -129,7 +124,6 @@ function appAccountUpdateName(payload) {
 function appLogout() {
   appSessionStore.$reset(); // clear store
   cookie.deleteCookie("accountid");
-  console.log(appSessionStore.accountMetadata.accountId);
 }
 
 function appAddStudent(payload) {

--- a/src/frontend/shortlist/src/App.vue
+++ b/src/frontend/shortlist/src/App.vue
@@ -61,7 +61,6 @@ function appAccountSignup(payload) {
 }
 
 function appAuthLogin(payload) {
-
   let success = (result) => {
     console.log("success: ", result.data);
     appSessionStore.loginState = true;

--- a/src/frontend/shortlist/src/App.vue
+++ b/src/frontend/shortlist/src/App.vue
@@ -88,7 +88,9 @@ function appAuthLogin(payload) {
 
 function appAccountUpdatePreferences(payload) {
   let requestPayload = {
-    accountId: appSessionStore.accountMetadata.accountId,
+    user_id: appSessionStore.accountMetadata.user_id,
+    user_name: appSessionStore.accountMetadata.user_name,
+    email: appSessionStore.accountMetadata.email,
     preferences: appSessionStore.accountMetadata.preferences,
   };
   requestPayload.preferences.recommendationPreferences = payload;
@@ -98,7 +100,7 @@ function appAccountUpdatePreferences(payload) {
       payload;
   };
   let fail = (err) => {
-    console.log(err);
+    console.log(err.response.data);
   };
   let req = apiClient.updatePreferences(requestPayload, success, fail);
   req.execute();

--- a/src/frontend/shortlist/src/api/shortlist.js
+++ b/src/frontend/shortlist/src/api/shortlist.js
@@ -88,6 +88,29 @@ export class temporarySignup {
         email: this.email,
         username: this.username,
         password: this.password,
+        userFirstName: this.firstName,
+        userLastName: this.lastName,
+        recommendationPreferences: {        
+          q1: {
+            Question:
+              "How important is an engaging curriculum & emphasis on critical thinking skills?",
+            Response: "",
+          },
+          q2: {
+            Question:
+              "How important is a school culture where students feel safe and supported to meet high expectations?",
+            Response: "",
+          },
+          q3: {
+            Question: "Is there a specific borough you are looking for?",
+            Response: "",
+          },
+          q4: {
+            Question:
+              "How would you rank your academic performance so far?",
+            Response: "",
+          },
+        },
       },
     })
     .then((result) => this.successCb(result))

--- a/src/frontend/shortlist/src/api/shortlist.js
+++ b/src/frontend/shortlist/src/api/shortlist.js
@@ -10,8 +10,9 @@ export default class ShortlistApi {
   createAccount() {
     return new fluentAccountCreate(this.baseEndpoint);
   }
-  getAccountMetadata() {
-    return new fluentAccountMetadata(this.baseEndpoint);
+  getAccountMetadata(payload, successCb, failCb) {
+    // return new fluentAccountMetadata(this.baseEndpoint);
+    return new tempUserMetadata(payload, successCb, failCb);
   }
   getRecommendations() {
     return new fluentRecommendations(this.baseEndpoint);
@@ -89,51 +90,26 @@ export class temporarySignup {
         password: this.password,
       },
     })
-      // user/email success;
-      /*
-      .then(() => {
-        // register the site account
-        axios({
-          method: "POST",
-          url: "https://api.shortlist.nyc/account/create",
-          headers: {},
-          data: {
-            email: this.email,
-            passwordHash: this.passwordHash,
-            accountType: this.accountType,
-            preferences: {
-              userFirstName: this.firstName,
-              userLastName: this.lastName,
-              recommendationPreferences: {
-                q1: {
-                  Question:
-                    "How important is an engaging curriculum & emphasis on critical thinking skills?",
-                  Response: "",
-                },
-                q2: {
-                  Question:
-                    "How much would you value the supportive environment provided by school?",
-                  Response: "",
-                },
-                q3: {
-                  Question: "Is there a spicific borough you are looking for?",
-                  Response: "",
-                },
-                q4: {
-                  Question:
-                    "How would you rank your academic performance so far?",
-                  Response: "",
-                },
-              },
-            },
-          },
-        })
-          .then((result) => this.successCb(result))
-          .catch((fail) => this.failCb(fail));
-      })
-      */
+    .then((result) => this.successCb(result))
+    .catch((err) => this.failCb(err));
+  }
+}
+
+export class tempUserMetadata {
+  constructor(payload, successCb, failCb) {
+    this.user_id = payload.userID;
+    this.successCb = successCb;
+    this.failCb = failCb;
+  }
+
+  execute() {
+    axios({
+      method: "GET",
+      url: "https://api.shortlist.nyc/auth/" + this.user_id + "/details",
+      headers: {},
+      data: "",
+    })
       .then((result) => this.successCb(result))
-      // email fail;
       .catch((err) => this.failCb(err));
   }
 }

--- a/src/frontend/shortlist/src/api/shortlist.js
+++ b/src/frontend/shortlist/src/api/shortlist.js
@@ -225,19 +225,23 @@ export class temporaryAcceptInvite {
 
 export class temporaryUpdatePreferences {
   constructor(payload, successCb, failCb) {
-    this.accountId = payload.accountId;
+    this.user_id = payload.user_id;
     this.preferences = payload.preferences;
+    this.email = payload.email;
+    this.username = payload.user_name;
     this.successCb = successCb;
     this.failCb = failCb;
   }
+  
   execute() {
     axios({
-      method: "POST",
-      url: "https://api.shortlist.nyc/account/update",
+      method: "PUT",
+      url: "https://api.shortlist.nyc/auth/" + this.user_id + "/details",
       headers: {},
       data: {
-        accountId: this.accountId,
         preferences: this.preferences,
+        username: this.username,
+        email: this.email
       },
     })
       .then((result) => this.successCb(result))

--- a/src/frontend/shortlist/src/api/shortlist.js
+++ b/src/frontend/shortlist/src/api/shortlist.js
@@ -7,7 +7,7 @@ export default class ShortlistApi {
   constructor(baseURL) {
     this.baseEndpoint = baseURL;
   }
-  createAccount() {
+  createAccount() { // not in use
     return new fluentAccountCreate(this.baseEndpoint);
   }
   getAccountMetadata(payload, successCb, failCb) {
@@ -17,7 +17,7 @@ export default class ShortlistApi {
   getRecommendations() {
     return new fluentRecommendations(this.baseEndpoint);
   }
-  loginAccount() {
+  loginAccount() { // not in use
     return new fluentAccountLogin(this.baseEndpoint);
   }
   signupUser(payload, successCb, failCb) {
@@ -79,7 +79,6 @@ export class temporarySignup {
   }
 
   execute() {
-    // send the email first
     axios({
       method: "POST",
       url: "https://api.shortlist.nyc/auth/register",

--- a/src/frontend/shortlist/src/api/shortlist.js
+++ b/src/frontend/shortlist/src/api/shortlist.js
@@ -1,5 +1,5 @@
 import { fluentAccountCreate } from "./endpoints/accountCreate";
-import { fluentAccountMetadata } from "./endpoints/accountMetadata";
+// import { fluentAccountMetadata } from "./endpoints/accountMetadata";
 import { fluentRecommendations } from "./endpoints/recommendations";
 import { fluentAccountLogin } from "./endpoints/accountLogin";
 
@@ -7,7 +7,8 @@ export default class ShortlistApi {
   constructor(baseURL) {
     this.baseEndpoint = baseURL;
   }
-  createAccount() { // not in use
+  createAccount() {
+    // not in use
     return new fluentAccountCreate(this.baseEndpoint);
   }
   getAccountMetadata(payload, successCb, failCb) {
@@ -17,7 +18,8 @@ export default class ShortlistApi {
   getRecommendations() {
     return new fluentRecommendations(this.baseEndpoint);
   }
-  loginAccount() { // not in use
+  loginAccount() {
+    // not in use
     return new fluentAccountLogin(this.baseEndpoint);
   }
   signupUser(payload, successCb, failCb) {
@@ -89,7 +91,7 @@ export class temporarySignup {
         password: this.password,
         userFirstName: this.firstName,
         userLastName: this.lastName,
-        recommendationPreferences: {        
+        recommendationPreferences: {
           q1: {
             Question:
               "How important is an engaging curriculum & emphasis on critical thinking skills?",
@@ -105,15 +107,14 @@ export class temporarySignup {
             Response: "",
           },
           q4: {
-            Question:
-              "How would you rank your academic performance so far?",
+            Question: "How would you rank your academic performance so far?",
             Response: "",
           },
         },
       },
     })
-    .then((result) => this.successCb(result))
-    .catch((err) => this.failCb(err));
+      .then((result) => this.successCb(result))
+      .catch((err) => this.failCb(err));
   }
 }
 
@@ -231,7 +232,7 @@ export class temporaryUpdatePreferences {
     this.successCb = successCb;
     this.failCb = failCb;
   }
-  
+
   execute() {
     axios({
       method: "PUT",
@@ -240,7 +241,7 @@ export class temporaryUpdatePreferences {
       data: {
         preferences: this.preferences,
         username: this.username,
-        email: this.email
+        email: this.email,
       },
     })
       .then((result) => this.successCb(result))

--- a/src/frontend/shortlist/src/router/index.js
+++ b/src/frontend/shortlist/src/router/index.js
@@ -10,7 +10,7 @@ const shortlistApi = new ShortlistApi("https://api.shortlist.nyc/");
 import VerifiedView from "../views/VerifiedView.vue";
 
 function getUserMetadata(payload, store) {
-  let data = { "userID": payload};
+  let data = { userID: payload };
   let success = (result) => {
     // console.log("got metadata: ", result.data);
     store.loginState = true;

--- a/src/frontend/shortlist/src/views/CategorizeView.vue
+++ b/src/frontend/shortlist/src/views/CategorizeView.vue
@@ -158,14 +158,12 @@ export default {
       console.log("SHARED LIST #:", e);
     },
     getRecommendations(count = 10) {
-      console.log("payload:", this.acctID);
       let req = shortlistApi
         .getRecommendations()
         .forAccountId(this.acctID)
         .count(count)
         .strategy("RANKING")
         .onSuccess((result) => {
-          console.log("categorize recs: ", Array.isArray(result.data));
           this.myRecommendations.push(...result.data);
         })
         .onFail((err) => {


### PR DESCRIPTION
- Save default preference questions and empty answers on registration
- router uses GET /auth/id/details to get and save user metadata
- update preferences saves using PUT /auth/id/details

Note: Since userFirstName and userLastName are not being saved at register at the moment, they will still not show up in profile.